### PR TITLE
Fixed medianBin not working according to its docstring

### DIFF
--- a/oscaar/mathMethods.py
+++ b/oscaar/mathMethods.py
@@ -5,6 +5,8 @@ Module for differential photometry
 Developed by Brett Morris, 2011-2013
 """
 
+import math
+
 import numpy as np
 from numpy import linalg as LA
 
@@ -167,13 +169,13 @@ def medianBin(time, flux, medianWidth):
         deviation of the points within each bin
     """
 
-    numberBins = len(time)/medianWidth
+    numberBins = int(math.ceil(len(time)/float(medianWidth)))
     binnedTime = np.arange(numberBins, dtype=float)
     binnedFlux = np.arange(numberBins, dtype=float)
     binnedStd = np.arange(numberBins, dtype=float)
-    for i in range(0, numberBins):
-        fluxInBin = flux[i*medianWidth:(i+1)*medianWidth+1]
-        binnedTime[i] = np.median(time[i*medianWidth:(i+1)*medianWidth+1])
+    for i in range(numberBins):
+        fluxInBin = flux[i*medianWidth:(i+1)*medianWidth]
+        binnedTime[i] = np.median(time[i*medianWidth:(i+1)*medianWidth])
         binnedFlux[i] = np.median(fluxInBin)
         binnedStd[i] = np.std(fluxInBin)
     return binnedTime, binnedFlux, binnedStd


### PR DESCRIPTION
As it stands medianBin creates bins with medianWidth + 1 elements in them, instead of medianWidth elements, as specified in the docstring (if I understand it correctly that is).

I'm not sure if rounding up numberBins is the right thing to do, as this can make the last bin have even just one element. On the other hand rounding it down would make it miss few datapoints in certain cases.